### PR TITLE
use https:// URL for sxor in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/google/oboe.git
 [submodule "externals/soxr"]
 	path = externals/soxr
-	url = git://git.code.sf.net/p/soxr/code
+	url = https://git.code.sf.net/p/soxr/code
 [submodule "externals/vorbis"]
 	path = externals/vorbis
 	url = https://github.com/xiph/vorbis.git


### PR DESCRIPTION

HTTPS Everywhere! This is a trivial fix to improve privacy and security.


https://sourceforge.net/p/soxr/code/ci/master/tree/#code